### PR TITLE
updating branch pin

### DIFF
--- a/.github/workflows/auto-format-reusable.yml
+++ b/.github/workflows/auto-format-reusable.yml
@@ -36,7 +36,7 @@ jobs:
         format-task: ${{ fromJson(inputs.format-tasks) }}
 
     steps:
-    - uses: cloudposse/github-action-auto-format@review-branch
+    - uses: cloudposse/github-action-auto-format@main
       with:
         format-task: ${{ matrix.format-task }}
         workflow-token: ${{ secrets.workflow-token }}

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -8,10 +8,12 @@ on:
 
 jobs:
   auto-format:
+    # For development reasons, this action is pinned to the `main` branch.
+    # However, we recommend that you choose a specific release to pin to.
+    # Consult https://github.com/cloudposse/github-action-auto-format/releases for a list of available releases.
+
     # only run on pull requests so long as they don't come from forks
     if: ${{ !( (github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository) ) }}
-    #runs-on: ubuntu-latest
-
     uses: cloudposse/github-action-auto-format/.github/workflows/auto-format-reusable.yml@review-branch
     with:
       # Delete "format-tasks:" values as desired to limit the scope of the overall auto-formatting task.


### PR DESCRIPTION
## what
* Updating action call version pin in `auto-format-reusable.yml` from `review-branch` to `main`.

## why
* This will run the action from the intended default branch, `main`.