### PR TITLE
configuring mergify to automerge README*-only PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,7 @@
+pull_request_rules:
+  - name: Automerge README*-only PRs
+    conditions:
+      - "-files~=^(?!README\..{2,4}).*$"
+    actions:
+      merge:
+        method: merge


### PR DESCRIPTION
## what
* Configuring Mergify (`.github/mergify.yml`) to auto-merge any PR that only modifies `README.*` files.

## why
* This reduces PR buildup by merging PRs that only contain docs changes and, thus, no functionality changes.

## references
* CPCO-244
* CPCO-581