### PR TITLE
Rebuilding docs on merge to master

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: '0 7 * * *'
   workflow_dispatch:
+  push:
+    branches:
+      - master
+      - main
+      - production
 
 jobs:
   auto-format:


### PR DESCRIPTION
## what
* Now triggering all formatting actions (`readme`, `github`, and `terraform`) on any merge to `master`, `main`, or `production`. In practice, since these all already run for every syncing of a PR, these will only actually make changes after an automatically-merged branch triggers them. I can't think of an example right now of such a thing, but I can imagine us having some kind of `mergify` setup that merges into master without going through any checks.

## why
* The original goal here was to auto-rebuild docs whenever changes were pushed to master, since those changes might have changed TF code without updating docs. As stated above, this is fairly unlikely, given that `github-action-auto-format` already triggers all of its actions, including `readme`, on every sync of a PR, but could happen with some combination of auto-generated PRs and mergify auto-merging, conceivably. So, this change, combined with a mergify auto-merge rule for docs-only PRs, would ensure that docs are always up to date.

## references
* CPCO-311
