### PR TITLE
updating branch pin from the defunct review-branch branch to the main branch

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -14,7 +14,7 @@ jobs:
 
     # only run on pull requests so long as they don't come from forks
     if: ${{ !( (github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository) ) }}
-    uses: cloudposse/github-action-auto-format/.github/workflows/auto-format-reusable.yml@review-branch
+    uses: cloudposse/github-action-auto-format/.github/workflows/auto-format-reusable.yml@main
     with:
       # Delete "format-tasks:" values as desired to limit the scope of the overall auto-formatting task.
       format-tasks: "[\"readme\", \"github\", \"terraform\"]"


### PR DESCRIPTION
## what
* Title says it all. This was overlooked when merging from `review-branch` previously.

## why
* Currently, the action tries on a branch that doesn't exist. Now, it might work.