### PR TITLE
Update github output syntax

### DIFF
--- a/scripts/github/pr_parameters.sh
+++ b/scripts/github/pr_parameters.sh
@@ -2,16 +2,16 @@
 
 # PR commit-message
 PR_COMMIT_MESSAGE="Automated update of .github files"
-echo "::set-output name=commit-message::$(echo $PR_COMMIT_MESSAGE)"
+echo "commit-message=$(echo $PR_COMMIT_MESSAGE)" >> $GITHUB_OUTPUT
 
 # PR body
 PR_BODY="This auto-generated PR adds standard files from the `cloudposse/.github` repo to this repo's `.github` folder"
-echo "::set-output name=pr-body::$(echo $PR_BODY)"
+echo "pr-body=$(echo $PR_BODY)" >> $GITHUB_OUTPUT
 
 # PR labels
 PR_LABELS="automated pr,no-release"
-echo "::set-output name=pr-labels::$(echo $PR_LABELS)"
+echo "pr-labels=$(echo $PR_LABELS)" >> $GITHUB_OUTPUT
 
 # PR title
 PR_TITLE="Automated update of .github files"
-echo "::set-output name=pr-title::$(echo $PR_TITLE)"
+echo "pr-title=$(echo $PR_TITLE)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## what
Update github output syntax

## why
Following github docs

## references
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/